### PR TITLE
Fix Navbar Duplicate Display on Window Resize

### DIFF
--- a/components/navbar.js
+++ b/components/navbar.js
@@ -10,6 +10,8 @@ import screens from "@/utils/tailwindScreens";
 
 export default function NavBar() {
   const [isOpen, setIsOpen] = useState(false);
+  const [isSmallScreen, setIsSmallScreen] = useState(false);
+  const mdScreen = parseInt(screens.md);
 
   useEffect(() => {
     const handleResize = () => {

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -6,12 +6,14 @@ import { AnimatePresence, motion } from "framer-motion";
 import Image from "next/image";
 import Link from "next/link";
 
+import screens from "@/utils/tailwindScreens";
+
 export default function NavBar() {
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     const handleResize = () => {
-      if (window.innerWidth >= 768) {
+      if (window.innerWidth >= screens.md) {
         setIsOpen(false);
       }
     };

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -38,6 +38,7 @@ export default function NavBar() {
               alt="BitHippie Logo"
               width={300}
               height={125}
+              priority
             />
           </Link>
 

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -9,17 +9,29 @@ import Link from "next/link";
 export default function NavBar() {
   const [isOpen, setIsOpen] = useState(false);
 
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 768) {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+
   return (
     <section className="w-full">
       <nav className="py-2.5 absolute bg-transparent w-full flex z-50">
         <div className="max-w-screen-xl flex flex-wrap items-center justify-between container">
           <Link href="/">
             <Image
-              src="/assets/images/logo.png" 
-              className="h-20" 
+              src="/assets/images/logo.png"
+              className="h-20"
               alt="BitHippie Logo"
               width={300}
-              height={125}/>
+              height={125}
+            />
           </Link>
 
           <button

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -115,11 +115,11 @@ export default function NavBar() {
               </AnimatePresence>
             </>
           ) : (
-            <div className="w-full hidden md:block md:w-auto bg-gradient-to-b from-transparent to-bg-dark-grey backdrop-blur-md opacity-95">
-              <ul className="mt-4 flex flex-col md:mt-0 md:flex-row md:space-x-8 md:text-sm md:font-medium">
+            <div className="w-auto">
+              <ul className="flex mt-0 flex-row space-x-8 text-sm font-medium">
                 <li>
                   <Link
-                    className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
+                    className="block p-0 border-gray-100 hover:bg-gray-50 border-0 hover:bg-transparent hover:text-cyan-700 text-platinum text-2xl hover:text-moss"
                     href="#services"
                   >
                     Services
@@ -127,7 +127,7 @@ export default function NavBar() {
                 </li>
                 <li>
                   <Link
-                    className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
+                    className="block p-0 border-gray-100 hover:bg-gray-50 border-0 hover:bg-transparent hover:text-cyan-700 text-platinum text-2xl hover:text-moss"
                     href="#faq"
                   >
                     FAQ
@@ -135,7 +135,7 @@ export default function NavBar() {
                 </li>
                 <li>
                   <Link
-                    className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
+                    className="block p-0 border-gray-100 hover:bg-gray-50 border-0 hover:bg-transparent hover:text-cyan-700 text-platinum text-2xl hover:text-moss"
                     href="#schedule"
                   >
                     Schedule
@@ -143,7 +143,7 @@ export default function NavBar() {
                 </li>
                 <li>
                   <Link
-                    className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
+                    className="block p-0 border-gray-100 hover:bg-gray-50 border-0 hover:bg-transparent hover:text-cyan-700 text-platinum text-2xl hover:text-moss"
                     href="#about"
                   >
                     About

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -59,88 +59,91 @@ export default function NavBar() {
               />
             </svg>
           </button>
-          <AnimatePresence>
-            {isOpen && (
-              <motion.div
-                initial={{ opacity: 0, height: 0 }}
-                animate={{ opacity: 1, height: "auto" }}
-                exit={{ opacity: 0, height: 0 }}
-                transition={{ duration: 0.5 }}
-                className="w-full bg-gradient-to-b from-transparent to-bg-dark-grey backdrop-blur-md opacity-95"
-              >
-                <ul className="mt-4 flex flex-col">
-                  <li>
-                    <Link
-                      className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
-                      href="#services"
-                    >
-                      Services
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
-                      href="#faq"
-                    >
-                      FAQ
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
-                      href="#schedule"
-                    >
-                      Schedule
-                    </Link>
-                  </li>
-                  <li>
-                    <Link
-                      className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
-                      href="#about"
-                    >
-                      About
-                    </Link>
-                  </li>
-                </ul>
-              </motion.div>
-            )}
-          </AnimatePresence>
-          <div className="w-full hidden md:block md:w-auto bg-gradient-to-b from-transparent to-bg-dark-grey backdrop-blur-md opacity-95">
-            <ul className="mt-4 flex flex-col md:mt-0 md:flex-row md:space-x-8 md:text-sm md:font-medium">
-              <li>
-                <Link
-                  className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
-                  href="#services"
+          {window.innerWidth < screens.md ? (
+            <AnimatePresence>
+              {isOpen && (
+                <motion.div
+                  initial={{ opacity: 0, height: 0 }}
+                  animate={{ opacity: 1, height: "auto" }}
+                  exit={{ opacity: 0, height: 0 }}
+                  transition={{ duration: 0.5 }}
+                  className="w-full bg-gradient-to-b from-transparent to-bg-dark-grey backdrop-blur-md opacity-95"
                 >
-                  Services
-                </Link>
-              </li>
-              <li>
-                <Link
-                  className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
-                  href="#faq"
-                >
-                  FAQ
-                </Link>
-              </li>
-              <li>
-                <Link
-                  className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
-                  href="#schedule"
-                >
-                  Schedule
-                </Link>
-              </li>
-              <li>
-                <Link
-                  className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
-                  href="#about"
-                >
-                  About
-                </Link>
-              </li>
-            </ul>
-          </div>
+                  <ul className="mt-4 flex flex-col">
+                    <li>
+                      <Link
+                        className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
+                        href="#services"
+                      >
+                        Services
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
+                        href="#faq"
+                      >
+                        FAQ
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
+                        href="#schedule"
+                      >
+                        Schedule
+                      </Link>
+                    </li>
+                    <li>
+                      <Link
+                        className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
+                        href="#about"
+                      >
+                        About
+                      </Link>
+                    </li>
+                  </ul>
+                </motion.div>
+              )}
+            </AnimatePresence>
+          ) : (
+            <div className="w-full hidden md:block md:w-auto bg-gradient-to-b from-transparent to-bg-dark-grey backdrop-blur-md opacity-95">
+              <ul className="mt-4 flex flex-col md:mt-0 md:flex-row md:space-x-8 md:text-sm md:font-medium">
+                <li>
+                  <Link
+                    className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
+                    href="#services"
+                  >
+                    Services
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
+                    href="#faq"
+                  >
+                    FAQ
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
+                    href="#schedule"
+                  >
+                    Schedule
+                  </Link>
+                </li>
+                <li>
+                  <Link
+                    className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 md:border-0 md:hover:bg-transparent md:hover:text-cyan-700 md:dark:hover:bg-transparent md:dark:hover:text-white text-platinum text-2xl hover:text-moss"
+                    href="#about"
+                  >
+                    About
+                  </Link>
+                </li>
+              </ul>
+            </div>
+          )}
         </div>
       </nav>
     </section>

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -15,14 +15,17 @@ export default function NavBar() {
 
   useEffect(() => {
     const handleResize = () => {
-      if (window.innerWidth >= screens.md) {
-        setIsOpen(false);
+      if (typeof window !== "undefined") {
+        setIsSmallScreen(window.innerWidth < mdScreen);
       }
     };
 
+    handleResize();
+
     window.addEventListener("resize", handleResize);
+
     return () => window.removeEventListener("resize", handleResize);
-  }, []);
+  }, [mdScreen]);
 
   return (
     <section className="w-full">

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -1,9 +1,10 @@
 "use client";
 
-import { useState } from "react";
-import Image from 'next/image'
-import Link from "next/link";
+import { useEffect, useState } from "react";
+
 import { AnimatePresence, motion } from "framer-motion";
+import Image from "next/image";
+import Link from "next/link";
 
 export default function NavBar() {
   const [isOpen, setIsOpen] = useState(false);

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -42,76 +42,78 @@ export default function NavBar() {
             />
           </Link>
 
-          <button
-            onClick={() => setIsOpen(!isOpen)}
-            type="button"
-            className="inline-flex items-center rounded-lg bg-transparent p-2 text-sm text-gray-500 focus:outline-none md:hidden"
-            aria-expanded="false"
-          >
-            <span className="sr-only">Open main menu</span>
-            <svg
-              className="w-5 h-5"
-              aria-hidden="true"
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 17 14"
-            >
-              <path
-                stroke="#AABD7B"
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth="2"
-                d="M1 1h15M1 7h15M1 13h15"
-              />
-            </svg>
-          </button>
-          {window.innerWidth < screens.md ? (
-            <AnimatePresence>
-              {isOpen && (
-                <motion.div
-                  initial={{ opacity: 0, height: 0 }}
-                  animate={{ opacity: 1, height: "auto" }}
-                  exit={{ opacity: 0, height: 0 }}
-                  transition={{ duration: 0.5 }}
-                  className="w-full bg-gradient-to-b from-transparent to-bg-dark-grey backdrop-blur-md opacity-95"
+          {isSmallScreen ? (
+            <>
+              <button
+                onClick={() => setIsOpen(!isOpen)}
+                type="button"
+                className="inline-flex items-center rounded-lg bg-transparent p-2 text-sm text-gray-500 focus:outline-none md:hidden"
+                aria-expanded="false"
+              >
+                <span className="sr-only">Open main menu</span>
+                <svg
+                  className="w-5 h-5"
+                  aria-hidden="true"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 17 14"
                 >
-                  <ul className="mt-4 flex flex-col">
-                    <li>
-                      <Link
-                        className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
-                        href="#services"
-                      >
-                        Services
-                      </Link>
-                    </li>
-                    <li>
-                      <Link
-                        className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
-                        href="#faq"
-                      >
-                        FAQ
-                      </Link>
-                    </li>
-                    <li>
-                      <Link
-                        className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
-                        href="#schedule"
-                      >
-                        Schedule
-                      </Link>
-                    </li>
-                    <li>
-                      <Link
-                        className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
-                        href="#about"
-                      >
-                        About
-                      </Link>
-                    </li>
-                  </ul>
-                </motion.div>
-              )}
-            </AnimatePresence>
+                  <path
+                    stroke="#AABD7B"
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth="2"
+                    d="M1 1h15M1 7h15M1 13h15"
+                  />
+                </svg>
+              </button>
+              <AnimatePresence>
+                {isOpen && (
+                  <motion.div
+                    initial={{ opacity: 0, height: 0 }}
+                    animate={{ opacity: 1, height: "auto" }}
+                    exit={{ opacity: 0, height: 0 }}
+                    transition={{ duration: 0.5 }}
+                    className="w-full bg-gradient-to-b from-transparent to-bg-dark-grey backdrop-blur-md opacity-95"
+                  >
+                    <ul className="mt-4 flex flex-col">
+                      <li>
+                        <Link
+                          className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
+                          href="#services"
+                        >
+                          Services
+                        </Link>
+                      </li>
+                      <li>
+                        <Link
+                          className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
+                          href="#faq"
+                        >
+                          FAQ
+                        </Link>
+                      </li>
+                      <li>
+                        <Link
+                          className="block py-2 pl-3 pr-4 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
+                          href="#schedule"
+                        >
+                          Schedule
+                        </Link>
+                      </li>
+                      <li>
+                        <Link
+                          className="block py-2 pl-3 pr-4 md:p-0 border-b border-gray-100 hover:bg-gray-50 text-platinum text-2xl hover:text-moss"
+                          href="#about"
+                        >
+                          About
+                        </Link>
+                      </li>
+                    </ul>
+                  </motion.div>
+                )}
+              </AnimatePresence>
+            </>
           ) : (
             <div className="w-full hidden md:block md:w-auto bg-gradient-to-b from-transparent to-bg-dark-grey backdrop-blur-md opacity-95">
               <ul className="mt-4 flex flex-col md:mt-0 md:flex-row md:space-x-8 md:text-sm md:font-medium">

--- a/utils/tailwindScreens.js
+++ b/utils/tailwindScreens.js
@@ -1,0 +1,8 @@
+import resolveConfig from "tailwindcss/resolveConfig";
+
+import tailwindConfig from "@/tailwind.config";
+
+const fullConfig = resolveConfig(tailwindConfig);
+const screens = fullConfig.theme.screens;
+
+export default screens;


### PR DESCRIPTION
This PR resolves an issue where the navbar was displayed twice when resizing the browser window from mobile to desktop view. The problem occurred because the mobile menu (`isOpen` state) did not reset when the window size changed.

#### Changes Made:
- Added a `useEffect` hook to listen for window resize events.
- Automatically reset the isOpen state to false if the window width exceeds 768px (Tailwind CSS's `md` breakpoint).