### PR TITLE
feat(seo): add robots.txt to block testimonial image indexing

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,9 @@
+# Block testimonial images from being indexed
+User-agent: *
+Disallow: /assets/images/testimonials/
+
+User-agent: Googlebot-Image
+Disallow: /assets/images/testimonials/
+
+User-agent: Bingbot
+Disallow: /assets/images/testimonials/


### PR DESCRIPTION
prevent search engines from indexing testimonial photos