### PR TITLE
fix(copy): replace excessive em dashes and fix hero mobile typography

### DIFF
--- a/app/team/page.js
+++ b/app/team/page.js
@@ -60,7 +60,7 @@ export default function TeamPage() {
               </RevealOnScroll>
               <RevealOnScroll>
                 <p className="mt-6">
-                  We approach business from the inside out—starting with personal 
+                  We approach business from the inside out, starting with personal
                   development, guided by quarterly goal-setting, supported by 
                   accountability, all within a culture of psychological safety.
                 </p>

--- a/components/faq.js
+++ b/components/faq.js
@@ -42,17 +42,17 @@ export default function FAQ() {
           <p className="my-4">
             This transitions into a{" "}
             <strong className="text-old-gold">Strategic Build</strong>{" "}
-            (6-12+ months) where we take ownership of major platform development—you focus on your science,
+            (6-12+ months) where we take ownership of major platform development: you focus on your science,
             we handle the technical execution.
           </p>
           <p className="my-4">
             Many clients <strong className="text-old-gold">continue partnering with us</strong>{" "}
-            on successive strategic initiatives as their platform needs evolve—whether 
+            on successive strategic initiatives as their platform needs evolve, whether
             that&apos;s expanding capabilities, integrating new data sources, or scaling
             infrastructure for growth.
           </p>
           <p className="my-4">
-            We function as your engineering partner—owning execution, integrating 
+            We function as your engineering partner, owning execution, integrating
             seamlessly with your team, and enabling your research operations.
           </p>
         </>

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -71,7 +71,7 @@ export default function NavBar() {
             />
           </Link>
 
-          {/* Hamburger button — CSS-hidden on md+ */}
+          {/* Hamburger button (CSS-hidden on md+) */}
           <button
             onClick={() => setIsOpen(!isOpen)}
             type="button"
@@ -96,7 +96,7 @@ export default function NavBar() {
             </svg>
           </button>
 
-          {/* Mobile dropdown — full-width flex child, CSS-hidden on md+ */}
+          {/* Mobile dropdown (full-width flex child, CSS-hidden on md+) */}
           <AnimatePresence>
             {isOpen && (
               <motion.div
@@ -131,7 +131,7 @@ export default function NavBar() {
             )}
           </AnimatePresence>
 
-          {/* Desktop nav — CSS-hidden below md */}
+          {/* Desktop nav (CSS-hidden below md) */}
           <div className="hidden md:block w-auto">
             <ul className="flex mt-0 flex-row space-x-8 text-sm font-medium">
               {navItems.map((item) => (

--- a/components/sections/engagement.js
+++ b/components/sections/engagement.js
@@ -12,7 +12,7 @@ export default function HowWeWork({ backgroundColor }) {
     {
       title: "Discovery Conversation",
       description:
-        "We meet with your scientists and leadership to understand what winning looks like—where you are, where you're headed, and what constraints shape your path. We explore fit and outline a roadmap to close that gap.",
+        "We meet with your scientists and leadership to understand what winning looks like: where you are, where you're headed, and what constraints shape your path. We explore fit and outline a roadmap to close that gap.",
     },
     {
       title: "Foundational Partnership (3-6 months)",

--- a/components/sections/experience.js
+++ b/components/sections/experience.js
@@ -45,10 +45,10 @@ export default function About({ backgroundColor }) {
           <p className="my-4">
             Good data systems accelerate research. When scientists can access 
             complete experimental records, run analyses in parallel, and iterate 
-            without infrastructure friction—discovery moves faster.
+            without infrastructure friction; discovery moves faster.
           </p>
           <p className="my-4">
-            Great engineering partnerships require more than technical skills—they 
+            Great engineering partnerships require more than technical skills; they
             demand deep understanding of your research operations, adaptability as 
             priorities shift, and genuine investment in your success.
           </p>

--- a/components/sections/hero.js
+++ b/components/sections/hero.js
@@ -11,7 +11,7 @@ export default function Hero() {
     >
       <div className="container flex flex-col items-center self-center text-center max-w-screen-xl">
         <RevealOnScroll>
-          <h1 className="text-platinum text-5xl md:text-6xl leading-normal md:leading-snug">
+          <h1 className="text-platinum  text-4xl sm:text-5xl md:text-6xl leading-snug md:leading-snug">
             Good Data Systems<br/>
             <span className="relative inline-block italic">
               Accelerate
@@ -22,7 +22,7 @@ export default function Hero() {
 
           <h2 className="text-platinum text-2xl my-8 md:text-2xl">
             We&apos;re your engineering partner for the data platforms, pipelines, and tools that
-            <br/>let your scientists focus on science, not wrestling with technology.
+            <br className="hidden lg:block"/>{" "}let your scientists focus on science, not wrestling with technology.
           </h2>
 
           <div className="flex place-content-center">

--- a/components/sections/outcomes.js
+++ b/components/sections/outcomes.js
@@ -42,7 +42,7 @@ export default function WeWorkTogether({ backgroundColor }) {
                 <p className="text-xl text-justify">
                   We build infrastructure and warehousing strategies that enable cross-functional analysis
                   across computational and wet lab teams. Your scientists discover correlations earlier,
-                  refine predictions with real-world results, and make faster decisions—while maintaining
+                  refine predictions with real-world results, and make faster decisions, while maintaining
                   appropriate access controls.
                 </p>
               </div>
@@ -71,7 +71,7 @@ export default function WeWorkTogether({ backgroundColor }) {
                 </p>
                 <p className="text-xl text-justify">
                   We build cloud infrastructure that enables parallel processing at scale. Your team gets answers
-                  fast—intelligently leveraging CPUs or GPUs to run workloads efficiently and cost-effectively.
+                  fast, intelligently leveraging CPUs or GPUs to run workloads efficiently and cost-effectively.
                 </p>
                 <div className="flex flex-col sm:flex-row flex-wrap items-center justify-around sm:space-x-8">
                   <Image
@@ -120,7 +120,7 @@ export default function WeWorkTogether({ backgroundColor }) {
                   workflows that don&apos;t match your science, and lock into expensive licensing.
                 </p>
                 <p className="text-xl text-justify">
-                  We build custom tools designed alongside your team—internal applications and interactive dashboards
+                  We build custom tools designed alongside your team: internal applications and interactive dashboards
                   that replace bloated SaaS products. You own the code, control the features, and set the direction.
                 </p>
               </div>

--- a/components/sections/schedule.js
+++ b/components/sections/schedule.js
@@ -18,10 +18,10 @@ export default function Schedule({ backgroundColor }) {
               Schedule a Discovery&nbsp;Call
             </h2>
             <p className="text-xl mb-8">
-              We partner with biotech companies across the spectrum—from 
-              venture-backed startups and computational biology companies to 
-              AI-driven drug discovery platforms and global pharmaceutical 
-              research organizations—building the data infrastructure that 
+              We partner with biotech companies across the spectrum, from
+              venture-backed startups and computational biology companies to
+              AI-driven drug discovery platforms and global pharmaceutical
+              research organizations, building the data infrastructure that
               accelerates discovery.
             </p>
             

--- a/tests/navbar-mobile.spec.js
+++ b/tests/navbar-mobile.spec.js
@@ -44,7 +44,7 @@ test.describe("Mobile nav scroll", () => {
     await page.waitForLoadState("networkidle");
   });
 
-  test("menu is closed on page load — no flash of nav items", async ({
+  test("menu is closed on page load: no flash of nav items", async ({
     page,
   }) => {
     // The hamburger button must be visible immediately (CSS-driven, no hydration delay)


### PR DESCRIPTION
Replace em dashes with contextually appropriate punctuation (commas, semicolons, colons, parentheses) across site copy and comments. Also tighten hero h1 line-height on mobile and make the h2 line break responsive (hidden below lg).